### PR TITLE
Add JsonClass annotations to enums where appropriate

### DIFF
--- a/src/main/kotlin/com/slack/auto/value/kotlin/EnumConversion.kt
+++ b/src/main/kotlin/com/slack/auto/value/kotlin/EnumConversion.kt
@@ -36,7 +36,7 @@ import javax.tools.Diagnostic.Kind.ERROR
  */
 @ExperimentalAvkApi
 public object EnumConversion {
-  @Suppress("ReturnCount")
+  @Suppress("ReturnCount", "ComplexMethod")
   @OptIn(DelicateKotlinPoetApi::class)
   public fun convert(
     elements: Elements,

--- a/src/main/kotlin/com/slack/auto/value/kotlin/EnumConversion.kt
+++ b/src/main/kotlin/com/slack/auto/value/kotlin/EnumConversion.kt
@@ -46,6 +46,7 @@ public object EnumConversion {
     val className = element.asClassName()
     val docs = element.parseDocs(elements)
     return className to TypeSpec.enumBuilder(className.simpleName)
+      .addAnnotations(element.classAnnotations())
       .addModifiers(element.visibility)
       .apply {
         docs?.let {
@@ -57,7 +58,7 @@ public object EnumConversion {
             val annotations = field.annotationMirrors
               .map {
                 if (it.annotationType.asTypeName() == JSON_CN) {
-                  isMoshiSerialized == true
+                  isMoshiSerialized = true
                 }
                 AnnotationSpec.get(it)
               }
@@ -75,7 +76,7 @@ public object EnumConversion {
           }
         }
 
-        if (isMoshiSerialized) {
+        if (isMoshiSerialized && annotationSpecs.none { it.typeName == JSON_CLASS_CN }) {
           addAnnotation(
             AnnotationSpec.builder(JSON_CLASS_CN)
               .addMember("generateAdapter = false")

--- a/src/main/kotlin/com/slack/auto/value/kotlin/utils.kt
+++ b/src/main/kotlin/com/slack/auto/value/kotlin/utils.kt
@@ -50,6 +50,7 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.asTypeVariableName
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.File
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
@@ -100,6 +101,7 @@ internal const val DOC_LINK_REGEX = "[0-9A-Za-z._]*"
 internal const val MAX_PARAMS = 7
 
 internal val JSON_CN = Json::class.asClassName()
+internal val JSON_CLASS_CN = JsonClass::class.asClassName()
 
 @ExperimentalAvkApi
 public fun TypeMirror.asSafeTypeName(): TypeName {

--- a/src/test/kotlin/com/slack/auto/value/kotlin/AutoValueKotlinExtensionTest.kt
+++ b/src/test/kotlin/com/slack/auto/value/kotlin/AutoValueKotlinExtensionTest.kt
@@ -396,7 +396,7 @@ class AutoValueKotlinExtensionTest {
             }
           }
 
-          @JsonClass(generateAdapter = true)
+          @JsonClass(generateAdapter = false)
           internal enum class ExampleEnum {
             ENUM_VALUE,
             @Redacted

--- a/src/test/kotlin/com/slack/auto/value/kotlin/AutoValueKotlinExtensionTest.kt
+++ b/src/test/kotlin/com/slack/auto/value/kotlin/AutoValueKotlinExtensionTest.kt
@@ -396,6 +396,7 @@ class AutoValueKotlinExtensionTest {
             }
           }
 
+          @JsonClass(generateAdapter = true)
           internal enum class ExampleEnum {
             ENUM_VALUE,
             @Redacted


### PR DESCRIPTION
We were accidentally omitting these before. This only applies it if they have `@Json`-annotated members or the enclosing AV class is annotated with `@JsonClass`