### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -43,7 +43,7 @@ jobs:
 
       - name: (Fail-only) Upload build reports
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
+#ECCN:Open Source
+#GUSINFO:Open Source,Open Source Workflow


### PR DESCRIPTION
Internal Salesforce request to add this:

> One of the many responsibilities of the OSPO is to ensure compliance of existing and new Open Source projects and GitHub repositories with our Policies and Procedures. Part of our FY26 V2MOM is compliance checking of the various GitHub orgs managed by the OSPO.
> 
> 
> The reason for this Email is that it's been determined that the `CODEOWNERS` file for your repo is either non-existant or, more likely, incorrect.
> 
> If you do have a `CODEOWNERS` file, it is likely then missing one or both of these required 2 lines, or else they are in an incorrect or unknown format:
> 
>     #ECCN:Open Source
>     #GUSINFO:Open Source,Open Source Workflow
> 
> These lines must be present in this exact format (but left aligned). If for example, your ECCN line is something like:
> 
>     #ECCN:5D002
> 
> or
> 
>     #ECCN:Open Source 5D002
> 
> then the file needs to be edited and corrected. All Open Source projects must have that ECCN value. Again, the `CODEOWNERS` file from the `oss-template` repo contains the correct format and data.
> 
> Any repos found to be still non-compliant after 45 days will be ARCHIVED and later moved to `private` visibility.
